### PR TITLE
Update progress_bar.py

### DIFF
--- a/mpire/progress_bar.py
+++ b/mpire/progress_bar.py
@@ -142,7 +142,7 @@ class ProgressBarHandler:
 
         # In case we're running tqdm in a notebook we need to apply a dirty hack to get progress bars working.
         # Solution adapted from https://github.com/tqdm/tqdm/issues/485#issuecomment-473338308
-        in_notebook = 'IPython' in sys.modules and 'IPKernelApp' in sys.modules['IPython'].get_ipython().config
+        in_notebook = 'IPython' in sys.modules and sys.modules['IPython'].get_ipython() is not None and 'IPKernelApp' in sys.modules['IPython'].get_ipython().config
         if in_notebook:
             print(' ', end='', flush=True)
 


### PR DESCRIPTION
when trying to run a django management command when ipython is installed, the check for ipython in sys.modules passes, but the get_ipython() returns None.